### PR TITLE
More robust file extension handling in -l

### DIFF
--- a/uguush
+++ b/uguush
@@ -83,7 +83,7 @@ screenshot() {
     if [ -f "/usr/share/mime/globs" ]; then
       urlext="$(curl -sf --head "${url}" | grep 'Content-Type: ' | head -1 | grep -Po '(?<=\ )[^\;]*')"
       urlext="$(echo "${urlext}" | cat -v | sed -e "s/\^M//")"
-      urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | grep -Po '(?<=\.)[^\n]*')"
+      urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | sort -r | head -1 | grep -Po '(?<=\.)[^\n]*')"
     else
       urlext="$(basename ${url})"
       urlext=${urlext#*.}

--- a/uguush
+++ b/uguush
@@ -80,10 +80,15 @@ screenshot() {
     FILE="$(mktemp --suffix=.png)"
     ${wshot} "${FILE}"
   elif [ "${lnk}" ]; then
-    urlext="$(basename ${url})"
-    urlext=${urlext#*.}
+    if [ -f "/usr/share/mime/globs" ]; then
+      urlext="$(curl -sf --head "${url}" | grep 'Content-Type' | grep -Po '(?<=\ )[^\;]*')"
+      urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | grep -Po '(?<=\.)[^\n]*')"
+    else
+      urlext="$(basename ${url})"
+      urlext=${urlext#*.}
+    fi
     FILE="$(mktemp --suffix=.${urlext})"
-    $(curl -s "${url}" > "${FILE}")
+    $(curl -sf "${url}" > "${FILE}")
   fi
 }
 

--- a/uguush
+++ b/uguush
@@ -81,7 +81,7 @@ screenshot() {
     ${wshot} "${FILE}"
   elif [ "${lnk}" ]; then
     if [ -f "/usr/share/mime/globs" ]; then
-      urlext="$(curl -sf --head "${url}" | grep 'Content-Type' | grep -Po '(?<=\ )[^\;]*')"
+      urlext="$(curl -sf --head "${url}" | grep 'Content-Type' | head -1 | grep -Po '(?<=\ )[^\;]*')"
       urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | grep -Po '(?<=\.)[^\n]*')"
     else
       urlext="$(basename ${url})"

--- a/uguush
+++ b/uguush
@@ -82,7 +82,7 @@ screenshot() {
   elif [ "${lnk}" ]; then
     if [ -f "/usr/share/mime/globs" ]; then
       urlext="$(curl -sf --head "${url}" | grep 'Content-Type: ' | head -1 | grep -Po '(?<=\ )[^\;]*')"
-      urlext="$(echo "${urlext}" | cat -v | sed -e "s/\^M//")"
+      urlext="$(echo "${urlext}" | sed -e "s/\\n//")"
       urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | sort -r | head -1 | grep -Po '(?<=\.)[^\n]*')"
     else
       urlext="$(basename ${url})"

--- a/uguush
+++ b/uguush
@@ -81,7 +81,7 @@ screenshot() {
     ${wshot} "${FILE}"
   elif [ "${lnk}" ]; then
     if [ -f "/usr/share/mime/globs" ]; then
-      urlext="$(curl -sf --head "${url}" | grep 'Content-Type' | head -1 | grep -Po '(?<=\ )[^\;]*')"
+      urlext="$(curl -sf --head "${url}" | grep 'Content-Type: ' | head -1 | grep -Po '(?<=\ )[^\;]*')"
       urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | grep -Po '(?<=\.)[^\n]*')"
     else
       urlext="$(basename ${url})"

--- a/uguush
+++ b/uguush
@@ -82,6 +82,7 @@ screenshot() {
   elif [ "${lnk}" ]; then
     if [ -f "/usr/share/mime/globs" ]; then
       urlext="$(curl -sf --head "${url}" | grep 'Content-Type: ' | head -1 | grep -Po '(?<=\ )[^\;]*')"
+      urlext="$(echo "${urlext}" | cat -v | sed -e "s/\^M//")"
       urlext="$(cat /usr/share/mime/globs | grep "${urlext}" | grep -Po '(?<=\.)[^\n]*')"
     else
       urlext="$(basename ${url})"


### PR DESCRIPTION
Checks the destination page's content-type and checks in /usr/share/mime/globs the correct extension to use. If the file is not present, fallback to the old method.
`curl -sf --head` only downloads the header, which means the content doesn't actually get downloaded 2 times in a row.