### PR TITLE
add mixtape + remove xpo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Options:
 
 `-h` Show this help message.
 
-`-o` Select a host to use. Can be uguu, teknik, 0x0, ptpb, maxfile, or xpo.
+`-o` Select a host to use. Can be uguu, teknik, 0x0, ptpb, maxfile, or mixtape.
 
 `-s` Take a selection screenshot.
 

--- a/uguush
+++ b/uguush
@@ -20,7 +20,7 @@ secs='0'
 
 # image host
 usehost='uguu'
-hosts='uguu teknik 0x0 xpo ptpb maxfile'
+hosts='uguu teknik 0x0 mixtape ptpb maxfile'
 shorteners='waaai 0x0 ptpb'
 
 ## EXIT IF NO ARGUMENTS ARE FOUND
@@ -51,7 +51,7 @@ Options:
     -d           Delay the screenshot by the specified number of seconds.
     -f           Take a fullscreen screenshot.
     -h           Show this help message.
-    -o           Select a host to use. Can be uguu, teknik, 0x0, ptpb, maxfile, or xpo.
+    -o           Select a host to use. Can be uguu, teknik, 0x0, ptpb, maxfile, or mixtape.
     -s           Take a selection screenshot.
     -t           Use HTTPS, if the host supports it.
     -u <file>    Upload a file.
@@ -106,18 +106,18 @@ upload() {
         teknik) upurl='https://api.teknik.io/upload/post' ;;
         0x0) upurl='https://0x0.st/' ;;
         uguu) upurl='unsupported' ;;
-        xpo) upurl='unsupported' ;;
         ptpb) upurl='https://ptpb.pw/' ;;
         maxfile) upurl='https://maxfile.ro/static/upload.php' ;;
+        mixtape) upurl='https://mixtape.moe/upload.php' ;;
       esac
     else
       case "${usehost}" in
         teknik) upurl='unsupported' ;;
         0x0) upurl='http://0x0.st/' ;;
         uguu) upurl='http://uguu.se/api.php?d=upload' ;;
-        xpo) upurl='http://xpo.pw/upload.php' ;;
         ptpb) upurl='unsupported' ;;
         maxfile) upurl='unsupported' ;;
+        mixtape) upurl='unsupported' ;;
       esac
     fi
 
@@ -141,10 +141,10 @@ upload() {
         result="${result##*name\":\"}"
         result="${result%%\"*}"
         result="https://u.teknik.io/${result}"
-      elif [ "${usehost}" = 'xpo' ]; then
+      elif [ "${usehost}" = 'mixtape' ]; then
         result="$(curl -sf -F files[]="@${FILE}" "${upurl}")"
         result="$(echo "${result}" | grep -Eo '"url":"[A-Za-z0-9]+.*",' | sed 's/"url":"//;s/",//')"
-        result="$(echo "http://u.xpo.pw/${result}")"
+        result="$(echo "${result//\\\//\/}")"
       elif [ "${usehost}" = 'ptpb' ]; then
         result="$(curl -sf -F c="@${FILE}" "${upurl}")"
         result="${result##*url: }"


### PR DESCRIPTION
xpo merged into mixtape and was shut down

I also propose to make mixtape the default host in sxhkdrc. While maxfile has been around longer, it doesn't appear to be up-to-date (creator's fork is actually 15 commits behind), and mixtape is hosted by drybones (guy behind 8chan archive, gitgud, and tweetsave), so it's quite reliable.