### PR TITLE
Fixed uploading to uguu.se

### DIFF
--- a/uguush
+++ b/uguush
@@ -114,7 +114,7 @@ upload() {
       case "${usehost}" in
         teknik) upurl='unsupported' ;;
         0x0) upurl='http://0x0.st/' ;;
-        uguu) upurl='http://uguu.se/api.php?d=upload' ;;
+        uguu) upurl='http://uguu.se/api.php?d=upload-tool' ;;
         ptpb) upurl='unsupported' ;;
         maxfile) upurl='unsupported' ;;
         mixtape) upurl='unsupported' ;;


### PR DESCRIPTION
Used the new "upload-tool" instead of "upload" in order to get a plain-text response, as described at http://uguu.se/?info